### PR TITLE
Fix file saving failure when filename contains illegal characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ class VideoDownloader {
           const { chapterNumber, content } = course
           try {
             const videoData = await this.getVideoData(content._id)
-            const title = videoData.title.replace('/', '-')
+            const regex = /[\\/:\*\?"<>\|]/g;
+            const title = videoData.title.replace(regex, "-")
             const { videos = [], subtitles = [] } = videoData.video
             const video = videos.find(item => item.height > 720)
             if (video) {


### PR DESCRIPTION
當有非法字元時，儲存會發生錯誤進而導致下載中斷